### PR TITLE
NSA-2495 use cdn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2546,9 +2546,9 @@
       "integrity": "sha1-DKx6nOUvVc1We0O9s5Im5yStUOc="
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -5186,11 +5186,6 @@
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -5305,11 +5300,6 @@
         "lodash.isarray": "3.0.4"
       }
     },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-    },
     "lodash.noop": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
@@ -5359,23 +5349,6 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
-    "lodash.template": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-      "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "requires": {
-        "lodash._reinterpolate": "3.0.0"
-      }
-    },
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
@@ -5396,6 +5369,12 @@
       "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
       "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
+    "login.dfe.async-retry": {
+      "version": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#ca9115e8840cdb9e609bddf842281e498f6ddee4",
+      "requires": {
+        "retry": "0.12.0"
+      }
+    },
     "login.dfe.audit.winston-sequelize-transport": {
       "version": "git+https://github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#a0a86a3c4e5ff9bb7b1dd8b4024208d62c8d7e31",
       "requires": {
@@ -5409,7 +5388,7 @@
     "login.dfe.config.schema.common": {
       "version": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#c88af037eebfce2b7b70cbade1f5103ef2346c5a",
       "requires": {
-        "simpl-schema": "1.5.5"
+        "simpl-schema": "1.5.6"
       }
     },
     "login.dfe.express-error-handling": {
@@ -5446,14 +5425,6 @@
       "requires": {
         "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#ca9115e8840cdb9e609bddf842281e498f6ddee4",
         "request-promise": "4.2.4"
-      },
-      "dependencies": {
-        "login.dfe.async-retry": {
-          "version": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#ca9115e8840cdb9e609bddf842281e498f6ddee4",
-          "requires": {
-            "retry": "0.12.0"
-          }
-        }
       }
     },
     "login.dfe.sanitization": {
@@ -5595,12 +5566,11 @@
       }
     },
     "message-box": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.0.tgz",
-      "integrity": "sha512-SPLfVDEM2YcAgV2IB0B5vOGjvqXSSw7ZibEeXcff8HYpxyG1Uj+XjgnGUGyR1C0EQCvPI3MBx3p7opt2CIQ2hw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.2.tgz",
+      "integrity": "sha512-A32m9D2ZaE08ZaXoE74AjcKwjtwwEhDT2EeY7A3YMAEB4ypL0uMZw7HegwZ806GIWyY4VLwe3kGO9reIdjwiRg==",
       "requires": {
-        "lodash.merge": "4.6.1",
-        "lodash.template": "4.4.0"
+        "lodash": "4.17.15"
       }
     },
     "methods": {
@@ -7285,12 +7255,12 @@
       "dev": true
     },
     "simpl-schema": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.5.5.tgz",
-      "integrity": "sha512-LEAKeqXS9VDpH7sVXmsIJsED7fdMj/WAP0roZw0u0IzOgQV7n3x7jcf722cl7WM6U5ANwI4wwv0dujLuwv266A==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.5.6.tgz",
+      "integrity": "sha512-fo06b4LsqXrFX159K+/e9/PYFa6/f3783uJZBhiASdRiPCCrx5FG8DbVPSkwEPkAV+4Sufxkee1eneckPFa2Tg==",
       "requires": {
         "clone": "2.1.2",
-        "extend": "3.0.1",
+        "extend": "3.0.2",
         "lodash.every": "4.6.0",
         "lodash.find": "4.6.0",
         "lodash.findwhere": "3.1.0",
@@ -7301,7 +7271,7 @@
         "lodash.pick": "4.4.0",
         "lodash.union": "4.6.0",
         "lodash.uniq": "4.5.0",
-        "message-box": "0.2.0",
+        "message-box": "0.2.2",
         "mongo-object": "0.1.3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5396,12 +5396,6 @@
       "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
       "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
-    "login.dfe.async-retry": {
-      "version": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#ca9115e8840cdb9e609bddf842281e498f6ddee4",
-      "requires": {
-        "retry": "0.12.0"
-      }
-    },
     "login.dfe.audit.winston-sequelize-transport": {
       "version": "git+https://github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#a0a86a3c4e5ff9bb7b1dd8b4024208d62c8d7e31",
       "requires": {
@@ -5419,7 +5413,7 @@
       }
     },
     "login.dfe.express-error-handling": {
-      "version": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#f238b07304d09e9d6d21a007e7e72985f355d4ba",
+      "version": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#c66d6550c7b20708bbc9d378af032a59e95cdc63",
       "requires": {
         "ejs": "2.5.7"
       }
@@ -5452,6 +5446,14 @@
       "requires": {
         "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#ca9115e8840cdb9e609bddf842281e498f6ddee4",
         "request-promise": "4.2.4"
+      },
+      "dependencies": {
+        "login.dfe.async-retry": {
+          "version": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#ca9115e8840cdb9e609bddf842281e498f6ddee4",
+          "requires": {
+            "retry": "0.12.0"
+          }
+        }
       }
     },
     "login.dfe.sanitization": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.17.13",
     "login.dfe.audit.winston-sequelize-transport": "git+https://github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#v2.9",
     "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v1.3",
-    "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v1.4",
+    "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v1.5",
     "login.dfe.healthcheck": "git+https://github.com/DFE-Digital/login.dfe.healthcheck.git#v1.5",
     "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v2.0.1",
     "login.dfe.notifications.client": "git+https://github.com/DFE-Digital/login.dfe.notifications.client.git#v3.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v1.0",
     "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v2",
     "morgan": "^1.9.1",
-    "simpl-schema": "^1.5.5",
+    "simpl-schema": "^1.5.6",
     "winston": "^2.4.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,7 @@ Object.assign(app.locals, {
 
 const errorPageRenderer = ejsErrorPages.getErrorPageRenderer({
   help: config.hostingEnvironment.helpUrl,
+  assets: assetsUrl,
 }, config.hostingEnvironment.env === 'dev');
 app.use(getErrorHandler({
   logger,


### PR DESCRIPTION
- Update express error handling to the latest version that uses cdn for asset delivery
- update vulnerable dependencies