### PR TITLE
[NSA-8069] Adjust honeypot fields

### DIFF
--- a/src/app/contactUs/postContactUs.js
+++ b/src/app/contactUs/postContactUs.js
@@ -143,7 +143,7 @@ const post = async (req, res) => {
   }
 
   // If either or both the honeypot fields are not blank, log the request, otherwise send it to the service desk.
-  if ([req.body.phoneNumber, req.body.password].some((x) => typeof x !== 'string' || x !== '')) {
+  if ([req.body.dsiFax, req.body.dsiWebsite].some((x) => typeof x !== 'string' || x !== '')) {
     logger.audit({
       type: 'contact-form',
       subType: 'spam-detection',

--- a/src/app/contactUs/views/contactUs.ejs
+++ b/src/app/contactUs/views/contactUs.ejs
@@ -24,14 +24,14 @@
                 <legend class="govuk-fieldset__legend govuk-visually-hidden">Contact DfE Sign-in service desk</legend>
 
                 <div class="govuk-form-group" style="display: none !important; visibility: hidden !important">
-                    <label class="govuk-label govuk-label--s" for="phoneNumber">Phone number</label>
-                    <div id="phone-hint" class="govuk-hint">This field is used for spam detection. Do not fill this in as your response will not be sent to the service desk.</div>
-                    <input class="govuk-input govuk-!-width-three-quarters" id="phoneNumber" name="phoneNumber" type="tel" aria-describedby="phone-hint">
+                    <label class="govuk-label govuk-label--s" for="dsiFax">Fax number</label>
+                    <div id="fax-hint" class="govuk-hint">This field is used for spam detection. Do not fill this in as your response will not be sent to the service desk.</div>
+                    <input class="govuk-input govuk-!-width-three-quarters" id="dsiFax" name="dsiFax" type="text" aria-describedby="fax-hint" tabindex="-1" autocomplete="off">
                 </div>
                 <div class="govuk-form-group" style="display: none !important; visibility: hidden !important">
-                    <label class="govuk-label govuk-label--s" for="password">Password</label>
-                    <div id="password-hint" class="govuk-hint">This field is used for spam detection. Do not fill this in as your response will not be sent to the service desk.</div>
-                    <input class="govuk-input govuk-!-width-three-quarters" id="password" name="password" type="password" aria-describedby="password-hint">
+                    <label class="govuk-label govuk-label--s" for="dsiWebsite">Website</label>
+                    <div id="website-hint" class="govuk-hint">This field is used for spam detection. Do not fill this in as your response will not be sent to the service desk.</div>
+                    <input class="govuk-input govuk-!-width-three-quarters" id="dsiWebsite" name="dsiWebsite" type="text" aria-describedby="website-hint" tabindex="-1" autocomplete="off">
                 </div>
 
                 <div class="govuk-form-group <%= (locals.validationMessages.name !== undefined) ? 'govuk-form-group--error' : '' %>">
@@ -99,8 +99,7 @@
                 <!-- Forces the additional information box to display if JavaScript is disabled. -->
                 <noscript><style>#typeOtherMessageGroup { display: block !important; }</style></noscript>
                 <div id="typeOtherMessageGroup" class="govuk-form-group govuk-character-count <%= (locals.validationMessages.typeOtherMessage !== undefined) ? 'govuk-form-group--error' : '' %>"
-                    data-module="govuk-character-count" data-maxlength="200"
-                    style="<%= locals.type !== 'other' ? 'display: none' : '' %>">
+                    data-module="govuk-character-count" data-maxlength="200" <%- (locals.type !== 'other') ? 'style="display: none"' : '' %>>
                     <label class="govuk-label govuk-label--s" for="typeOtherMessage">Give us a short summary of your issue</label>
                     <% if (locals.validationMessages.typeOtherMessage !== undefined) { %>
                         <span id="validation-typeOtherMessage" class="govuk-error-message">

--- a/test/app/contactUs/contactUs.post.test.js
+++ b/test/app/contactUs/contactUs.post.test.js
@@ -73,8 +73,8 @@ describe('When handling post of contact form', () => {
         service: 'test service',
         type: 'test type',
         typeOtherMessage: '',
-        phoneNumber: '',
-        password: '',
+        dsiFax: '',
+        dsiWebsite: '',
       },
       session: {},
       query: {},
@@ -583,8 +583,8 @@ describe('When handling post of contact form', () => {
   });
 
   it('should log the request and redirect if one of the honeypot fields is filled in', async () => {
-    req.body.phoneNumber = '';
-    req.body.password = 'foo';
+    req.body.dsiFax = '';
+    req.body.dsiWebsite = 'foo';
 
     await postContactForm(req, res);
 
@@ -595,8 +595,8 @@ describe('When handling post of contact form', () => {
   });
 
   it('should log the request and redirect if both of the honeypot fields are filled in', async () => {
-    req.body.phoneNumber = 'foo';
-    req.body.password = 'foo';
+    req.body.dsiFax = 'foo';
+    req.body.dsiWebsite = 'foo';
 
     await postContactForm(req, res);
 
@@ -607,8 +607,8 @@ describe('When handling post of contact form', () => {
   });
 
   it('should log the request and redirect if one of the honeypot fields is not a string', async () => {
-    req.body.phoneNumber = [];
-    req.body.password = '';
+    req.body.dsiFax = [];
+    req.body.dsiWebsite = '';
 
     await postContactForm(req, res);
 
@@ -619,8 +619,8 @@ describe('When handling post of contact form', () => {
   });
 
   it('should log the request and redirect if both of the honeypot fields are not strings', async () => {
-    req.body.phoneNumber = [];
-    req.body.password = undefined;
+    req.body.dsiFax = [];
+    req.body.dsiWebsite = undefined;
 
     await postContactForm(req, res);
 
@@ -631,8 +631,8 @@ describe('When handling post of contact form', () => {
   });
 
   it('should log the correct details if the honeypot fields are filled in or a different type', async () => {
-    req.body.phoneNumber = 'foo';
-    req.body.password = [];
+    req.body.dsiFax = 'foo';
+    req.body.dsiWebsite = [];
     req.headers['x-forwarded-for'] = '127.0.0.1, 192.168.1.1';
 
     const {
@@ -659,8 +659,8 @@ describe('When handling post of contact form', () => {
   });
 
   it('should send the support request and redirect if both of the honeypot fields are empty strings', async () => {
-    req.body.phoneNumber = '';
-    req.body.password = '';
+    req.body.dsiFax = '';
+    req.body.dsiWebsite = '';
 
     await postContactForm(req, res);
 


### PR DESCRIPTION
## Description

Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8069

Modification to the contact form, to make the honeypot fields less like to trigger for false positives, as they are currently more common than expected. Based on research, that appears to be related to using "password" as a field, as browsers and password managers will auto-fill that.

## Changes
- Changed the phone number field to be fax number, and changed it to a `text` input type so it's far less likely to be auto-filled.
- Changed the password field to website and changed it to a `text` input type, as the `password` type field (even if it isn't visible) was the most likely culprit of false positives, as browsers/password managers tend to fill anything with a `password` input type.
- Fixed a small linting issue with how the styles were set for the `typeOtherMessage` field.