### PR TITLE
DSI-6999 ITHC fix running docker compose as non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,14 @@ ADD config /home/site/wwwroot/config
 COPY src /home/site/wwwroot/src
 COPY package.json /home/site/wwwroot
 
+ARG USERNAME=node
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupmod --gid $USER_GID $USERNAME \
+    && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
+    && chown -R $USER_UID:$USER_GID /home/$USERNAME
+
 RUN npm install pm2 -g
 ENV PM2HOME /pm2home
 
@@ -42,6 +50,7 @@ COPY Docker/init.sh /home/site/wwwroot/init.sh
 
 RUN chmod 755 init.sh
 RUN chmod 755 tokenization.ps1
+USER $USERNAME
 
 EXPOSE 8080 2221
 


### PR DESCRIPTION
In order to resolve the issue raised by he IT Health check April 2024

Which provides the benefit of improving our security

Update our current docker to meet the best practise security configuration

(Issue: Container ran as root user, Rationale: 'node' user forces the running image to run as a non-root user to ensure least privileges)

Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-6941