### PR TITLE
[NSA-8291] Fix hidden field visibility

### DIFF
--- a/src/app/contactUs/views/contactUs.ejs
+++ b/src/app/contactUs/views/contactUs.ejs
@@ -23,12 +23,12 @@
 
                 <legend class="govuk-fieldset__legend govuk-visually-hidden">Contact DfE Sign-in service desk</legend>
 
-                <div class="govuk-form-group" style="display: none !important; visibility: hidden !important">
+                <div class="govuk-form-group govuk-!-display-none">
                     <label class="govuk-label govuk-label--s" for="dsiFax">Fax number</label>
                     <div id="fax-hint" class="govuk-hint">This field is used for spam detection. Do not fill this in as your response will not be sent to the service desk.</div>
                     <input class="govuk-input govuk-!-width-three-quarters" id="dsiFax" name="dsiFax" type="text" aria-describedby="fax-hint" tabindex="-1" autocomplete="off">
                 </div>
-                <div class="govuk-form-group" style="display: none !important; visibility: hidden !important">
+                <div class="govuk-form-group govuk-!-display-none">
                     <label class="govuk-label govuk-label--s" for="dsiWebsite">Website</label>
                     <div id="website-hint" class="govuk-hint">This field is used for spam detection. Do not fill this in as your response will not be sent to the service desk.</div>
                     <input class="govuk-input govuk-!-width-three-quarters" id="dsiWebsite" name="dsiWebsite" type="text" aria-describedby="website-hint" tabindex="-1" autocomplete="off">
@@ -98,8 +98,8 @@
 
                 <!-- Forces the additional information box to display if JavaScript is disabled. -->
                 <noscript><style>#typeOtherMessageGroup { display: block !important; }</style></noscript>
-                <div id="typeOtherMessageGroup" class="govuk-form-group govuk-character-count <%= (locals.validationMessages.typeOtherMessage !== undefined) ? 'govuk-form-group--error' : '' %>"
-                    data-module="govuk-character-count" data-maxlength="200" <%- (locals.type !== 'other') ? 'style="display: none"' : '' %>>
+                <div id="typeOtherMessageGroup" class="govuk-form-group govuk-character-count<%= (locals.type !== 'other') ? ' govuk-!-display-none' : '' %><%= (locals.validationMessages.typeOtherMessage !== undefined) ? ' govuk-form-group--error' : '' %>"
+                    data-module="govuk-character-count" data-maxlength="200">
                     <label class="govuk-label govuk-label--s" for="typeOtherMessage">Give us a short summary of your issue</label>
                     <% if (locals.validationMessages.typeOtherMessage !== undefined) { %>
                         <span id="validation-typeOtherMessage" class="govuk-error-message">
@@ -168,11 +168,11 @@
         const inputGroup = document.getElementById(`${targetId}OtherMessageGroup`);
         const input = document.getElementById(`${targetId}OtherMessage`);
 
-        if (event.target.value === 'other') {
-            inputGroup.style.display = 'block';
+        if (event.target.value === "other") {
+            inputGroup.classList.remove("govuk-!-display-none");
             input.focus();
         } else {
-            inputGroup.style.display = 'none';
+            inputGroup.classList.add("govuk-!-display-none");
             input.value = '';
         }
     }

--- a/src/app/contactUs/views/contactUs.ejs
+++ b/src/app/contactUs/views/contactUs.ejs
@@ -78,14 +78,14 @@
                             type="text" <% if (locals.validationMessages.urn !== undefined) { %> aria-invalid="true" aria-describedby="validation-urn" <% } %> value="<%=urn%>">
                 </div>
 
-                <div class="govuk-form-group <%= (locals.validationMessages.type !== undefined) ? 'govuk-form-group--error' : '' %>">
+                <div class="govuk-form-group <%= (locals.validationMessages.type !== undefined) ? 'govuk-form-group--error' : '' %>" data-target="typeOtherMessageGroup">
                     <label class="govuk-label govuk-label--s" for="type">What do you need help with?</label>
                     <% if (locals.validationMessages.type !== undefined) { %>
                         <span id="validation-type" class="govuk-error-message">
                             <span class="govuk-visually-hidden">Error:</span> <%=locals.validationMessages.type %>
                         </span>
                     <% } %>
-                    <select id="type" name="type" class="govuk-select govuk-!-width-three-quarters">
+                    <select id="type" name="type" class="govuk-select govuk-!-width-three-quarters" data-option="other" data-clear="true">
                         <option disabled selected value>Tell us what you need help with</option>
                         <option value="create-account" <%= locals.type === 'create-account' ? 'selected' : '' %>>Setting up a DfE Sign-in account</option>
                         <option value="service-access" <%= locals.type === 'service-access' ? 'selected' : '' %>>Using a DfE service</option>
@@ -96,9 +96,7 @@
                     </select>
                 </div>
 
-                <!-- Forces the additional information box to display if JavaScript is disabled. -->
-                <noscript><style>#typeOtherMessageGroup { display: block !important; }</style></noscript>
-                <div id="typeOtherMessageGroup" class="govuk-form-group govuk-character-count<%= (locals.type !== 'other') ? ' govuk-!-display-none' : '' %><%= (locals.validationMessages.typeOtherMessage !== undefined) ? ' govuk-form-group--error' : '' %>"
+                <div id="typeOtherMessageGroup" class="show-when-js-disabled js-hidden govuk-form-group govuk-character-count <%= (locals.validationMessages.typeOtherMessage !== undefined) ? ' govuk-form-group--error' : '' %>"
                     data-module="govuk-character-count" data-maxlength="200">
                     <label class="govuk-label govuk-label--s" for="typeOtherMessage">Give us a short summary of your issue</label>
                     <% if (locals.validationMessages.typeOtherMessage !== undefined) { %>
@@ -158,22 +156,3 @@
     </div>
 
 </div>
-
-<script>
-    const typeSelect = document.getElementById("type");
-    typeSelect.addEventListener("change", showHideOtherMessageInput);
-
-    function showHideOtherMessageInput(event) {
-        const targetId = event.target.id;
-        const inputGroup = document.getElementById(`${targetId}OtherMessageGroup`);
-        const input = document.getElementById(`${targetId}OtherMessage`);
-
-        if (event.target.value === "other") {
-            inputGroup.classList.remove("govuk-!-display-none");
-            input.focus();
-        } else {
-            inputGroup.classList.add("govuk-!-display-none");
-            input.value = '';
-        }
-    }
-</script>

--- a/src/index.js
+++ b/src/index.js
@@ -55,9 +55,9 @@ const init = async () => {
   const imgSources = [self, allowedOrigin];
 
   if (config.hostingEnvironment.env === 'dev') {
-    scriptSources.push('localhost');
-    styleSources.push('localhost');
-    imgSources.push('localhost');
+    scriptSources.push('localhost:*');
+    styleSources.push('localhost:*');
+    imgSources.push('localhost:*');
   }
 
   app.use(helmet.contentSecurityPolicy({


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8291

Changes:
- Replaces static `style` attributes of spam honeypot fields in the contact form with the `govuk-!-display-none` class to achieve the same effect without needing to hard-code a hash to the content security policy.
- Replaces conditional `style` attribute for the summary/`typeOtherMessage` field with the with the `govuk-!-display-none` class to achieve the same effect without needing to hard-code a hash to the content security policy.
- Updated JS that toggles the summary field to be visible using the class instead of toggling the style.
- Added 1 hash to the Content Security Policy for styles, to allow for the `<noscript>` tag to show the summary box if JS is disabled.