### PR TITLE
[DSI-7295] Replace `csurf` with `csrf-csrf`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "body-parser": "^1.18.2",
         "cookie-parser": "^1.4.3",
         "cookie-session": "^2.0.0-beta.3",
-        "csurf": "^1.9.0",
+        "csrf-csrf": "^3.0.8",
         "ejs": "^3.1.8",
         "email-validator": "^2.0.4",
         "express": "^4.16.2",
@@ -3366,17 +3366,12 @@
         "node": ">= 8"
       }
     },
-    "node_modules/csrf": {
-      "version": "3.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/csrf/-/csrf-3.1.0.tgz",
-      "integrity": "sha1-7HXpZW0ATWdLjvW6R7Qfv9bLnDA=",
+    "node_modules/csrf-csrf": {
+      "version": "3.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/csrf-csrf/-/csrf-csrf-3.0.8.tgz",
+      "integrity": "sha1-tz2+/3t3hau973QLbnUtgL236aw=",
       "dependencies": {
-        "rndm": "1.2.0",
-        "tsscmp": "1.0.6",
-        "uid-safe": "2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8"
+        "http-errors": "^2.0.0"
       }
     },
     "node_modules/css": {
@@ -3396,72 +3391,6 @@
       "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
       "dependencies": {
         "css": "^2.0.0"
-      }
-    },
-    "node_modules/csurf": {
-      "version": "1.11.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/csurf/-/csurf-1.11.0.tgz",
-      "integrity": "sha1-qww8ZjRjQZK9PW9LhhviCADutho=",
-      "dependencies": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "csrf": "3.1.0",
-        "http-errors": "~1.7.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/csurf/node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/http-errors": {
-      "version": "1.7.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
-    },
-    "node_modules/csurf/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/data-view-buffer": {
@@ -7950,14 +7879,6 @@
         }
       ]
     },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/range-parser/-/range-parser-1.2.1.tgz",
@@ -8265,11 +8186,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/rndm": {
-      "version": "1.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rndm/-/rndm-1.2.0.tgz",
-      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -9260,17 +9176,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha1-Kz1cckDo/C5Y+Komnl7knAhXvTo=",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "body-parser": "^1.18.2",
     "cookie-parser": "^1.4.3",
     "cookie-session": "^2.0.0-beta.3",
-    "csurf": "^1.9.0",
+    "csrf-csrf": "^3.0.8",
     "ejs": "^3.1.8",
     "email-validator": "^2.0.4",
     "express": "^4.16.2",

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,13 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const session = require('cookie-session');
+const { doubleCsrf } = require('csrf-csrf');
 const expressLayouts = require('express-ejs-layouts');
 const http = require('http');
 const https = require('https');
 const path = require('path');
 const helmet = require('helmet');
 const sanitization = require('login.dfe.sanitization');
-const csurf = require('csurf');
 const { getErrorHandler, ejsErrorPages } = require('login.dfe.express-error-handling');
 const flash = require('login.dfe.express-flash-2');
 
@@ -81,26 +81,36 @@ const init = async () => {
   logger.info('helmet setup complete');
 
   let expiryInMinutes = 30;
-  const sessionExpiry = parseInt(config.hostingEnvironment.sessionCookieExpiryInMinutes);
+  const sessionExpiry = parseInt(config.hostingEnvironment.sessionCookieExpiryInMinutes, 10);
   if (!isNaN(sessionExpiry)) {
     expiryInMinutes = sessionExpiry;
   }
+
   app.use(session({
     keys: [config.hostingEnvironment.sessionSecret],
     maxAge: expiryInMinutes * 60000, // Expiry in milliseconds
     httpOnly: true,
     secure: true,
   }));
+
   app.use((req, res, next) => {
     req.session.now = Date.now();
     next();
   });
 
-  const csrf = csurf({
-    cookie: {
+  const { doubleCsrfProtection: csrf } = doubleCsrf({
+    getSecret: (req) => req.secret,
+    // eslint-disable-next-line no-underscore-dangle
+    getTokenFromRequest: (req) => req.body._csrf,
+    secret: config.hostingEnvironment.csrfSecret,
+    cookieName: `${config.hostingEnvironment.host}.x-csrf`,
+    cookieOptions: {
+      sameSite: 'strict',
       secure: true,
-      httpOnly: true,
+      signed: true,
     },
+    size: 64,
+    ignoredMethods: ['GET', 'HEAD', 'OPTIONS'],
   });
 
   if (config.hostingEnvironment.env !== 'dev') {
@@ -121,7 +131,7 @@ const init = async () => {
   // finished setting up authentication middleware
 
   app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(cookieParser());
+  app.use(cookieParser(config.hostingEnvironment.sessionSecret));
   app.use(sanitization());
   app.set('view engine', 'ejs');
   app.use(express.static(path.resolve(__dirname, 'dist')));

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -22,8 +22,14 @@ const accessIdentifiers = new SimpleSchema({
   'identifiers.organisation': patterns.uuid,
 });
 
-accessIdentifiers.extend(schemas.apiClient);
+const hostingEnvironmentSchema = new SimpleSchema({
+  csrfSecret: {
+    type: String,
+    optional: true,
+  },
+});
 
+accessIdentifiers.extend(schemas.apiClient);
 
 const adapterSchema = new SimpleSchema({
   type: {
@@ -42,7 +48,7 @@ const adapterSchema = new SimpleSchema({
 
 const schema = new SimpleSchema({
   loggerSettings: schemas.loggerSettings,
-  hostingEnvironment: schemas.hostingEnvironment,
+  hostingEnvironment: schemas.hostingEnvironment.extend(hostingEnvironmentSchema),
   applications: schemas.apiClient,
   access: accessIdentifiers,
   notifications: notificationsSchema,


### PR DESCRIPTION
### Summary
Jira ticket: [DSI-7295](https://dfe-secureaccess.atlassian.net/browse/DSI-7295)

### Changes
- Removed vulnerable and deprecated package `csurf`
- Added and configured `csrf-csrf` as a replacement for `csurf`
- Passed `config.hostingEnvironment.sessionSecret` into `CookieParser` to support encrypted cookies by `csrf-csrf`
- Update config schema to add `csrfSecret`