### PR TITLE
[DSI-7289] Direct users to ServiceNow in Manage Console

### DIFF
--- a/src/app/dashboard/views/manageDashboard.ejs
+++ b/src/app/dashboard/views/manageDashboard.ejs
@@ -77,7 +77,7 @@
             <ul class="govuk-list">
                 <li>
                     <h3 class="govuk-heading-s">
-                        <a class="govuk-link-bold" href="/contact-us">Contact DfE Sign-in </a>
+                        <a class="govuk-link-bold" target="_blank" href="<%=locals.urls.serviceNow%>">Contact DfE Sign-in (opens in new tab)</a>
                     </h3>
                 </li>
             </ul>

--- a/src/app/manageConsole/views/aboutManageConsole.ejs
+++ b/src/app/manageConsole/views/aboutManageConsole.ejs
@@ -45,7 +45,7 @@
             Contact us
         </h2>
         <p class="govuk-body">
-            You can <a class="govuk-link" href="/contact-us">contact DfE Sign-in</a> for further support, including how to:
+            You can <a class="govuk-link" target="_blank" href="<%=locals.urls.serviceNow%>">contact DfE Sign-in <span class="govuk-visually-hidden">(opens in new tab)</span></a> for further support, including how to:
         </p>
         <ol class="govuk-list govuk-list--bullet ">
             <li>change a service title</li>
@@ -83,7 +83,7 @@
             <ul class="govuk-list">
                 <li>
                     <h3 class="govuk-heading-s">
-                        <a class="govuk-link-bold" href="/contact-us">Contact DfE Sign-in </a>
+                        <a class="govuk-link-bold" target="_blank" href="<%=locals.urls.serviceNow%>">Contact DfE Sign-in (opens in new tab)</a>
                     </h3>
                 </li>
             </ul>

--- a/src/app/manageConsole/views/aboutManageConsole.ejs
+++ b/src/app/manageConsole/views/aboutManageConsole.ejs
@@ -64,12 +64,12 @@
         <!-- related articles to show at the bottom of the page -->
         <div id="related-articles" class="help-section-title">
             <h2 class="govuk-heading-m">
-                Related help topics
+                Most popular help topics
             </h2>
             <ul class="govuk-list">
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-manage-users">Manage Users</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-manage-users">Manage users</a></li>
                 <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-view-and-search-organisations">View and search organisations</a></li>
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-edit-service-config">Edit Service Configuration</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-edit-service-config">Edit service configuration</a></li>
                 <li><a class="govuk-link-bold" href="/error/<%= locals.serviceId%>/page-coming-soon">Manage service access</a></li>
             </ul>
         </div>

--- a/src/app/manageConsole/views/howtoEditServiceConfig.ejs
+++ b/src/app/manageConsole/views/howtoEditServiceConfig.ejs
@@ -344,7 +344,7 @@
             <ul class="govuk-list">
                 <li>
                     <h3 class="govuk-heading-s">
-                        <a class="govuk-link-bold" href="/contact-us">Contact DfE Sign-in </a>
+                        <a class="govuk-link-bold" target="_blank" href="<%=locals.urls.serviceNow%>">Contact DfE Sign-in (opens in new tab)</a>
                     </h3>
                 </li>
             </ul>

--- a/src/app/manageConsole/views/howtoEditServiceConfig.ejs
+++ b/src/app/manageConsole/views/howtoEditServiceConfig.ejs
@@ -325,10 +325,10 @@
         <!-- related articles to show at the bottom of the page -->
         <div id="related-articles" class="help-section-title">
             <h2 class="govuk-heading-m">
-                Related help topics
+                Most popular help topics
             </h2>
             <ul class="govuk-list">
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/about-manage-console">About DfE Manage Console</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/about-manage-console">About DfE Sign-in manage console</a></li>
                 <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-manage-users">Manage Users</a></li>
                 <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-view-and-search-organisations">View and search organisations</a></li>
                 <li><a class="govuk-link-bold" href="/error/<%= locals.serviceId%>/page-coming-soon">Manage service access</a></li>

--- a/src/app/manageConsole/views/howtoManageUsers.ejs
+++ b/src/app/manageConsole/views/howtoManageUsers.ejs
@@ -117,7 +117,7 @@
         <div id="remove-users">
             <h3 class="govuk-heading-l">Remove users</h3>
             <p class="govuk-body">
-                If a user has left your organisation, an approver within the organisation needs to contact the <a class="govuk-link" href="/contact-us">DfE Sign-in support team</a> to deactivate the user's account.
+                If a user has left your organisation, an approver within the organisation needs to contact the <a class="govuk-link" target="_blank" href="<%=locals.urls.serviceNow%>">DfE Sign-in support team <span class="govuk-visually-hidden">(opens in new tab)</span></a> to deactivate the user's account.
             </p>
             <p class="govuk-body">
                 Whilst an approver can remove a user's access, only a member of the DfE Sign-in support team can remove a user's account.
@@ -154,7 +154,7 @@
             <ul class="govuk-list">
                 <li>
                     <h3 class="govuk-heading-s">
-                        <a class="govuk-link-bold" href="/contact-us">Contact DfE Sign-in </a>
+                        <a class="govuk-link-bold" target="_blank" href="<%=locals.urls.serviceNow%>">Contact DfE Sign-in (opens in new tab)</a>
                     </h3>
                 </li>
             </ul>

--- a/src/app/manageConsole/views/howtoManageUsers.ejs
+++ b/src/app/manageConsole/views/howtoManageUsers.ejs
@@ -135,12 +135,12 @@
         <!-- related articles to show at the bottom of the page -->
         <div id="related-articles" class="help-section-title">
             <h2 class="govuk-heading-m">
-                Related help topics
+                Most popular help topics
             </h2>
             <ul class="govuk-list">
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/about-manage-console">About DfE Manage Console</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/about-manage-console">About DfE Sign-in manage console</a></li>
                 <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-view-and-search-organisations">View and search organisations</a></li>
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-edit-service-config">Edit Service Configuration</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-edit-service-config">Edit service configuration</a></li>
                 <li><a class="govuk-link-bold" href="/error/<%= locals.serviceId%>/page-coming-soon">Manage service access</a></li>
             </ul>
         </div>

--- a/src/app/manageConsole/views/howtoViewAndSearchOrganisations.ejs
+++ b/src/app/manageConsole/views/howtoViewAndSearchOrganisations.ejs
@@ -43,7 +43,7 @@
             </ol>
 
             <p class="govuk-body">
-                If you cannot find the organisation you're looking for, contact the <a class="govuk-link" href="/contact-us">DfE Sign-in support team</a>.        
+                If you cannot find the organisation you're looking for, contact the <a class="govuk-link" target="_blank" href="<%=locals.urls.serviceNow%>">DfE Sign-in support team <span class="govuk-visually-hidden">(opens in new tab)</span></a>.        
             </p>
         </div>
 
@@ -145,7 +145,7 @@
             <ul class="govuk-list">
                 <li>
                     <h3 class="govuk-heading-s">
-                        <a class="govuk-link-bold" href="/contact-us">Contact DfE Sign-in </a>
+                        <a class="govuk-link-bold" target="_blank" href="<%=locals.urls.serviceNow%>">Contact DfE Sign-in (opens in new tab)</a>
                     </h3>
                 </li>
             </ul>

--- a/src/app/manageConsole/views/howtoViewAndSearchOrganisations.ejs
+++ b/src/app/manageConsole/views/howtoViewAndSearchOrganisations.ejs
@@ -126,12 +126,12 @@
         <!-- related articles to show at the bottom of the page -->
         <div id="related-articles" class="help-section-title">
             <h2 class="govuk-heading-m">
-                Related help topics
+                Most popular help topics
             </h2>
             <ul class="govuk-list">
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/about-manage-console">About DfE Manage Console</a></li>
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-manage-users">Manage Users</a></li>
-                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-edit-service-config">Edit Service Configuration</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/about-manage-console">About DfE Sign-in manage console</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-manage-users">Manage users</a></li>
+                <li><a class="govuk-link-bold" href="/manageConsole/<%= locals.serviceId%>/how-to-edit-service-config">Edit service configuration</a></li>
                 <li><a class="govuk-link-bold" href="/error/<%= locals.serviceId%>/page-coming-soon">Manage service access</a></li>
             </ul>
         </div>

--- a/src/app/shared/views/layout.ejs
+++ b/src/app/shared/views/layout.ejs
@@ -179,9 +179,9 @@
                     </li>
                     <li class="govuk-footer__inline-list-item">
                         <% if (locals.title !== 'DfE Sign-in'){ %>
-                            <a class="govuk-footer__link" href="https://dfe.service-now.com/serviceportal?id=sc_cat_item&sys_id=0c00c1afdb6bc8109402e1aa4b961937&sysparm_category=2f6e34afdb6bc8109402e1aa4b9619aa">
-                                Contact us
-                                </a>
+                            <a class="govuk-footer__link" target="_blank" href="<%=locals.urls.serviceNow%>">
+                                Contact us <span class="govuk-visually-hidden">(opens in new tab)</span>
+                            </a>
                             <%} else {%>
                             <a class="govuk-footer__link" href="/contact-us">
                             Contact us

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,7 @@ const init = async () => {
       manageConsole: config.hostingEnvironment.manageConsoleUrl,
       assets: assetsUrl,
       survey: config.hostingEnvironment.surveyUrl,
+      serviceNow: config.hostingEnvironment.serviceNowUrl,
     },
     app: {
       environmentBannerMessage: config.hostingEnvironment.environmentBannerMessage,


### PR DESCRIPTION
## Summary
Jira ticket: [DSI-7268](https://dfe-secureaccess.atlassian.net/browse/DSI-7289)

## Changes
- Updated links within Manage Console Help Pages that say ‘Contact DfE Sign-in’ should take the user to the ServiceNow as Manage Console. 

## Related PR
- https://github.com/DFE-Digital/login.dfe.dsi-config/pull/30