### PR TITLE
Add npm script 'dev:checks' to improve developer tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "dev": "settings='./config/login.dfe.help.dev.json' node src/index.js",
+    "dev:checks": "npm run lint && npm run test",
     "format": "prettier . --write",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
By developer request adds a helpful script to run `lint` and `test` commands in quick succession.