### PR TITLE
[NSA-8988] Update how to edit service config to remove token response…

### DIFF
--- a/src/app/manageConsole/views/howtoEditServiceConfig.ejs
+++ b/src/app/manageConsole/views/howtoEditServiceConfig.ejs
@@ -192,9 +192,8 @@
             The OAuth framework has several response types. When configuring a service, you can select 1 or combinations of the following response types:
         </p>
         <ul class="govuk-list govuk-list--bullet">
-            <li>span</li>
+            <li>code</li>
             <li>id_token</li>
-            <li>token</li>
         </ul>
         <p class="govuk-body ">
             Depending on the response type you select, it will automatically determine the authentication flow. There are 3 authentication flows that can be decided:
@@ -224,19 +223,7 @@
                     <td class="govuk-table__cell">Implicit flow</td>
                 </tr>
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell"><span style="background-color: rgb(235, 232, 232); color:#d4351c;">id_token</span> and <span style="background-color: rgb(235, 232, 232); color:#d4351c;">token</span></td>
-                    <td class="govuk-table__cell">Implicit flow</td>
-                </tr>
-                <tr class="govuk-table__row">
                     <td class="govuk-table__cell"><span style="background-color: rgb(235, 232, 232); color:#d4351c;">code</span> and <span style="background-color: rgb(235, 232, 232); color:#d4351c;">id_token</span></td>
-                    <td class="govuk-table__cell">Hybrid flow</td>
-                </tr>
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell"><span style="background-color: rgb(235, 232, 232); color:#d4351c;">code</span> and <span style="background-color: rgb(235, 232, 232); color:#d4351c;">token</span></td>
-                    <td class="govuk-table__cell">Hybrid flow</td>
-                </tr>
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell"><span style="background-color: rgb(235, 232, 232); color:#d4351c;">code</span>, <span style="background-color: rgb(235, 232, 232); color:#d4351c;">id_token</span> and <span style="background-color: rgb(235, 232, 232); color:#d4351c;">token</span></td>
                     <td class="govuk-table__cell">Hybrid flow</td>
                 </tr>
             </body>
@@ -247,7 +234,7 @@
             For example, if you select <span  style=" background-color: rgb(235, 232, 232); color:#d4351c;">code</span> as your response type, this means authorization flow will automatically be chosen as your flow.
         </p>
         <p class="govuk-body ">
-            If you select <span  style="background-color: rgb(235, 232, 232); color:#d4351c;">id_token</span> and <span style="background-color: rgb(235, 232, 232); color:#d4351c;">token</span> as your response type, this means implicit flow will automatically be chosen as your flow.
+            If you select <span  style="background-color: rgb(235, 232, 232); color:#d4351c;">code</span> and <span style="background-color: rgb(235, 232, 232); color:#d4351c;">id_token</span> as your response type, this means hybrid flow will automatically be chosen as your flow.
         </p>
         <p class="govuk-body ">
             For further details on response types go to ‘3. Authentication’ on <a  class="govuk-link" href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a>.
@@ -332,7 +319,7 @@
             You can view or change the API secret on the ‘Edit service configuration’ page by clicking ‘Show’ or ‘Regenerate’ next to the API secret field.
         </p>
         <p class="govuk-body end-of-section">
-            Updated January 2025
+            Updated March 2026
         </p>
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">


### PR DESCRIPTION
… type
This pull request updates the documentation in the `howtoEditServiceConfig.ejs` view to clarify supported OAuth response types and authentication flows, and to correct outdated information. The main changes focus on removing references to unsupported response types and updating flow descriptions.

Clarification and correction of OAuth response types and flows:

* Removed references to the `token` response type from the list of supported OAuth response types, leaving only `code` and `id_token` as options.
* Updated the authentication flow table by removing combinations involving the `token` response type, ensuring only valid combinations are shown.
* Corrected the explanation of which response type combinations result in implicit or hybrid flows, removing mention of `id_token` and `token` for implicit flow and updating the hybrid flow description to use `code` and `id_token`.

Documentation update:

* Changed the "Updated" date at the end of the section from January 2025 to March 2026 to reflect the latest revision.