### PR TITLE
fix(NSA-9688): hide service only when all three params are truthy

### DIFF
--- a/src/app/shared/utils.js
+++ b/src/app/shared/utils.js
@@ -8,6 +8,7 @@ const getAndMapExternalServices = async (correlationId) => {
   const allServices = (await listAllServices(correlationId)) || [];
   const externalServices = allServices.services.filter((x) => {
     if (x.isExternalService !== true) return false;
+    if (x.isIdOnlyService && isTruthy(x.isHiddenService)) return false;
     const p = x.relyingParty?.params;
     const isFullyHidden =
       isTruthy(p?.hideApprover) &&

--- a/src/app/shared/utils.js
+++ b/src/app/shared/utils.js
@@ -9,12 +9,7 @@ const getAndMapExternalServices = async (correlationId) => {
   const externalServices = allServices.services.filter((x) => {
     if (x.isExternalService !== true) return false;
     if (x.isIdOnlyService && isTruthy(x.isHiddenService)) return false;
-    const p = x.relyingParty?.params;
-    const isFullyHidden =
-      isTruthy(p?.hideApprover) &&
-      isTruthy(p?.hideSupport) &&
-      isTruthy(p?.helpHidden);
-    return !isFullyHidden;
+    return !isTruthy(x.relyingParty?.params?.helpHidden);
   });
   const services = uniqBy(
     externalServices.map((service) => ({

--- a/src/app/shared/utils.js
+++ b/src/app/shared/utils.js
@@ -2,17 +2,19 @@ const { listAllServices } = require("../../infrastructure/applications");
 const sortBy = require("lodash/sortBy");
 const uniqBy = require("lodash/uniqBy");
 
+const isTruthy = (v) => v === true || v === 1 || v === "true" || v === "1";
+
 const getAndMapExternalServices = async (correlationId) => {
   const allServices = (await listAllServices(correlationId)) || [];
-  const externalServices = allServices.services.filter(
-    (x) =>
-      x.isExternalService === true &&
-      !(
-        x.relyingParty &&
-        x.relyingParty.params &&
-        x.relyingParty.params.helpHidden === "true"
-      ),
-  );
+  const externalServices = allServices.services.filter((x) => {
+    if (x.isExternalService !== true) return false;
+    const p = x.relyingParty?.params;
+    const isFullyHidden =
+      isTruthy(p?.hideApprover) &&
+      isTruthy(p?.hideSupport) &&
+      isTruthy(p?.helpHidden);
+    return !isFullyHidden;
+  });
   const services = uniqBy(
     externalServices.map((service) => ({
       id: service.id,

--- a/src/app/shared/utils.js
+++ b/src/app/shared/utils.js
@@ -8,7 +8,15 @@ const getAndMapExternalServices = async (correlationId) => {
   const allServices = (await listAllServices(correlationId)) || [];
   const externalServices = allServices.services.filter((x) => {
     if (x.isExternalService !== true) return false;
-    if (x.isIdOnlyService && isTruthy(x.isHiddenService)) return false;
+    if (x.isIdOnlyService) {
+      const params = x.relyingParty?.params;
+      return !(
+        isTruthy(x.isHiddenService) &&
+        isTruthy(params?.hideApprover) &&
+        isTruthy(params?.hideSupport) &&
+        isTruthy(params?.helpHidden)
+      );
+    }
     return !isTruthy(x.relyingParty?.params?.helpHidden);
   });
   const services = uniqBy(

--- a/test/app/contactUs/contactUs.get.test.js
+++ b/test/app/contactUs/contactUs.get.test.js
@@ -131,7 +131,7 @@ describe("when displaying the contact us page", () => {
     expect(res.render.mock.calls[0][1].services).toHaveLength(0);
   });
 
-  it("should keep a service visible when only helpHidden is truthy", async () => {
+  it("should hide a service when only helpHidden is truthy", async () => {
     listAllServices.mockReturnValue({
       services: [
         {
@@ -145,7 +145,7 @@ describe("when displaying the contact us page", () => {
 
     await getContactUs(req, res);
 
-    expect(res.render.mock.calls[0][1].services.map((s) => s.id)).toContain(
+    expect(res.render.mock.calls[0][1].services.map((s) => s.id)).not.toContain(
       "svc-partial",
     );
   });

--- a/test/app/contactUs/contactUs.get.test.js
+++ b/test/app/contactUs/contactUs.get.test.js
@@ -113,6 +113,24 @@ describe("when displaying the contact us page", () => {
     expect(res.render.mock.calls[0][1].services).toHaveLength(0);
   });
 
+  it("should exclude id-only services where isHiddenService is truthy", async () => {
+    listAllServices.mockReturnValue({
+      services: [
+        {
+          id: "svc-hidden-id-only",
+          name: "Hidden Id Only Service",
+          isExternalService: true,
+          isIdOnlyService: true,
+          isHiddenService: 1,
+        },
+      ],
+    });
+
+    await getContactUs(req, res);
+
+    expect(res.render.mock.calls[0][1].services).toHaveLength(0);
+  });
+
   it("should keep a service visible when only helpHidden is truthy", async () => {
     listAllServices.mockReturnValue({
       services: [

--- a/test/app/contactUs/contactUs.get.test.js
+++ b/test/app/contactUs/contactUs.get.test.js
@@ -69,4 +69,66 @@ describe("when displaying the contact us page", () => {
       referrer: "/test_referrer",
     });
   });
+
+  const fullyHiddenService = (id, paramValue) => ({
+    id,
+    name: "Hidden Service",
+    isExternalService: true,
+    relyingParty: {
+      params: {
+        hideApprover: paramValue,
+        hideSupport: paramValue,
+        helpHidden: paramValue,
+      },
+    },
+  });
+
+  it("should exclude services where all three hide params are string 'true'", async () => {
+    listAllServices.mockReturnValue({
+      services: [fullyHiddenService("h1", "true")],
+    });
+
+    await getContactUs(req, res);
+
+    expect(res.render.mock.calls[0][1].services).toHaveLength(0);
+  });
+
+  it("should exclude services where all three hide params are integer 1", async () => {
+    listAllServices.mockReturnValue({
+      services: [fullyHiddenService("h2", 1)],
+    });
+
+    await getContactUs(req, res);
+
+    expect(res.render.mock.calls[0][1].services).toHaveLength(0);
+  });
+
+  it("should exclude services where all three hide params are boolean true", async () => {
+    listAllServices.mockReturnValue({
+      services: [fullyHiddenService("h3", true)],
+    });
+
+    await getContactUs(req, res);
+
+    expect(res.render.mock.calls[0][1].services).toHaveLength(0);
+  });
+
+  it("should keep a service visible when only helpHidden is truthy", async () => {
+    listAllServices.mockReturnValue({
+      services: [
+        {
+          id: "svc-partial",
+          name: "Partial Hide Service",
+          isExternalService: true,
+          relyingParty: { params: { helpHidden: "true" } },
+        },
+      ],
+    });
+
+    await getContactUs(req, res);
+
+    expect(res.render.mock.calls[0][1].services.map((s) => s.id)).toContain(
+      "svc-partial",
+    );
+  });
 });

--- a/test/app/contactUs/contactUs.get.test.js
+++ b/test/app/contactUs/contactUs.get.test.js
@@ -113,7 +113,7 @@ describe("when displaying the contact us page", () => {
     expect(res.render.mock.calls[0][1].services).toHaveLength(0);
   });
 
-  it("should exclude id-only services where isHiddenService is truthy", async () => {
+  it("should exclude id-only services only when all four hide conditions are truthy", async () => {
     listAllServices.mockReturnValue({
       services: [
         {
@@ -122,6 +122,13 @@ describe("when displaying the contact us page", () => {
           isExternalService: true,
           isIdOnlyService: true,
           isHiddenService: 1,
+          relyingParty: {
+            params: {
+              hideApprover: "true",
+              hideSupport: "true",
+              helpHidden: "true",
+            },
+          },
         },
       ],
     });
@@ -129,6 +136,27 @@ describe("when displaying the contact us page", () => {
     await getContactUs(req, res);
 
     expect(res.render.mock.calls[0][1].services).toHaveLength(0);
+  });
+
+  it("should include id-only services where isHiddenService is truthy but not all params are truthy", async () => {
+    listAllServices.mockReturnValue({
+      services: [
+        {
+          id: "svc-partial-id-only",
+          name: "Partially Hidden Id Only Service",
+          isExternalService: true,
+          isIdOnlyService: true,
+          isHiddenService: 1,
+          relyingParty: { params: { helpHidden: "true" } },
+        },
+      ],
+    });
+
+    await getContactUs(req, res);
+
+    expect(res.render.mock.calls[0][1].services.map((s) => s.id)).toContain(
+      "svc-partial-id-only",
+    );
   });
 
   it("should hide a service when only helpHidden is truthy", async () => {


### PR DESCRIPTION
## NSA-9688: Filter hidden services from the contact us service dropdown

### What
This PR ensures hidden services do not appear in the "Tell us which service you are using" dropdown on the help `/contact-us` page.

### Changes
- `utils.js` updated to filter services where `helpHidden` is truthy
- For ID-only services, also checks `isHiddenService` so services hidden via the DB flag are correctly excluded
- Contact us tests updated to cover both the hidden and visible cases

### Files changed
- `src/app/shared/utils.js`
- `test/app/contactUs/contactUs.get.test.js`
