### PR TITLE
refactor(NSA-9688): help/utils.js uses isHiddenForHelp from API

### DIFF
--- a/src/app/shared/utils.js
+++ b/src/app/shared/utils.js
@@ -3,7 +3,9 @@ const sortBy = require("lodash/sortBy");
 const uniqBy = require("lodash/uniqBy");
 
 const getAndMapExternalServices = async (correlationId) => {
-  const allServices = (await listAllServices(correlationId)) || [];
+  const allServices = (await listAllServices(correlationId)) || {
+    services: [],
+  };
   const externalServices = allServices.services.filter(
     (x) => x.isExternalService === true && !x.isHiddenForHelp,
   );

--- a/src/app/shared/utils.js
+++ b/src/app/shared/utils.js
@@ -5,13 +5,7 @@ const uniqBy = require("lodash/uniqBy");
 const getAndMapExternalServices = async (correlationId) => {
   const allServices = (await listAllServices(correlationId)) || [];
   const externalServices = allServices.services.filter(
-    (x) =>
-      x.isExternalService === true &&
-      !(
-        x.relyingParty &&
-        x.relyingParty.params &&
-        x.relyingParty.params.helpHidden === "true"
-      ),
+    (x) => x.isExternalService === true && !x.isHiddenForHelp,
   );
   const services = uniqBy(
     externalServices.map((service) => ({

--- a/test/app/contactUs/contactUs.get.test.js
+++ b/test/app/contactUs/contactUs.get.test.js
@@ -29,11 +29,13 @@ describe("when displaying the contact us page", () => {
           id: "service1",
           name: "analyse school performance",
           isExternalService: true,
+          isHiddenForHelp: false,
         },
         {
           id: "service2",
           name: "COLLECT",
           isExternalService: true,
+          isHiddenForHelp: false,
         },
       ],
     });
@@ -68,5 +70,38 @@ describe("when displaying the contact us page", () => {
     expect(res.render.mock.calls[0][1]).toMatchObject({
       referrer: "/test_referrer",
     });
+  });
+
+  it("should exclude services where isHiddenForHelp is true", async () => {
+    listAllServices.mockReset().mockReturnValue({
+      services: [
+        {
+          id: "hidden-svc",
+          name: "Hidden Service",
+          isExternalService: true,
+          isHiddenForHelp: true,
+        },
+      ],
+    });
+    await getContactUs(req, res);
+    const services = res.render.mock.calls[0][1].services;
+    expect(services).toHaveLength(0);
+  });
+
+  it("should include services where isHiddenForHelp is false", async () => {
+    listAllServices.mockReset().mockReturnValue({
+      services: [
+        {
+          id: "visible-svc",
+          name: "Visible Service",
+          isExternalService: true,
+          isHiddenForHelp: false,
+        },
+      ],
+    });
+    await getContactUs(req, res);
+    const services = res.render.mock.calls[0][1].services;
+    expect(services).toHaveLength(1);
+    expect(services[0].id).toBe("visible-svc");
   });
 });


### PR DESCRIPTION
## NSA-9688 — Toggle whether or not service is hidden via manage

Filters services with `isHiddenForHelp: true` out of the help-facing service list. The `isHiddenForHelp` flag is a computed field returned by the applications API — it is set by the manage console hide service toggle.

### What changed

- Service listing queries use the raw/computed-fields path so `isHiddenForHelp` is available.
- Services where `isHiddenForHelp === true` are excluded from results shown on the help site.

### Testing

Unit tests cover:
- Services with `isHiddenForHelp: true` are excluded from the rendered list
- Services with `isHiddenForHelp: false` are included as normal
